### PR TITLE
Fixed logic error in Pancake router contract

### DIFF
--- a/projects/v3-periphery/contracts/base/PeripheryPayments.sol
+++ b/projects/v3-periphery/contracts/base/PeripheryPayments.sol
@@ -55,13 +55,15 @@ abstract contract PeripheryPayments is IPeripheryPayments, PeripheryImmutableSta
         address recipient,
         uint256 value
     ) internal {
-        if (token == WETH9 && address(this).balance >= value) {
-            // pay with WETH9
-            IWETH9(WETH9).deposit{value: value}(); // wrap only what is needed to pay
-            IWETH9(WETH9).transfer(recipient, value);
-        } else if (payer == address(this)) {
-            // pay with tokens already in the contract (for the exact input multihop case)
-            TransferHelper.safeTransfer(token, recipient, value);
+        if (payer == address(this)) {
+            if (token == WETH9 && address(this).balance >= value) {
+                // pay with WETH9
+                IWETH9(WETH9).deposit{value: value}(); // wrap only what is needed to pay
+                IWETH9(WETH9).transfer(recipient, value);
+            } else {
+                // pay with tokens already in the contract (for the exact input multihop case)
+                TransferHelper.safeTransfer(token, recipient, value);
+            }
         } else {
             // pull payment
             TransferHelper.safeTransferFrom(token, payer, recipient, value);


### PR DESCRIPTION
Currently the pay function in the smart router contract has an logic error. When the function is used to deposit WETH the actual behaviour is that this WETH gets wrapped and sent from the router contract rather than the payer address.

The check about there being enough eth in the contract to wrap them should be done after the check that payer is the current contract.

The current uses of this function might not trigger this logic error, but the method definitely behaves differently than one would expect, potentially causing downstream issues or even attack vectors.